### PR TITLE
Stable

### DIFF
--- a/core/api/xiaomihome.php
+++ b/core/api/xiaomihome.php
@@ -39,11 +39,12 @@ if (init('type') == 'aquara') {
             $data = json_decode($body['data'], true);
             foreach ($data as $key => $value) {
                 if ($body['cmd'] == 'heartbeat' && $key == 'status') {
-                    if ($body['model'] == 'gateway'){
-                        xiaomihome::receiveAquaraData(init('gateway'), $body['model'], $key, $value);
-                    } else {
-                        xiaomihome::receiveAquaraData($body['sid'], $body['model'], $key, $value);
-                    }
+                    return;
+                }
+                if ($body['model'] == 'gateway'){
+                    xiaomihome::receiveAquaraData(init('gateway'), $body['model'], $key, $value);
+                } else {
+                    xiaomihome::receiveAquaraData($body['sid'], $body['model'], $key, $value);
                 }
             }
         }

--- a/core/api/xiaomihome.php
+++ b/core/api/xiaomihome.php
@@ -39,7 +39,7 @@ if (init('type') == 'aquara') {
             $data = json_decode($body['data'], true);
             foreach ($data as $key => $value) {
                 if ($body['cmd'] == 'heartbeat' && $key == 'status') {
-                    return;
+                    continue;
                 }
                 if ($body['model'] == 'gateway'){
                     xiaomihome::receiveAquaraData(init('gateway'), $body['model'], $key, $value);


### PR DESCRIPTION
Le commit bug for plugs ne fait que envoyer a receiveAquaraData les message de type heartbeat avec la key status tous les autres messages sont droppés.

Je propose un revert.

Pour corriger le probleme des plugs, l'update des données se fait sur heartbeat mais comme la key status est avant les key inuse, power_consumed et load_power. le return stoppe le traitement de la ligne et ne traite donc jamais les keys suivante. un continue permet de passer a la key suivante et de drop que le status