### PR TITLE
Arrondi le pourcentage de batterie en entier

### DIFF
--- a/core/class/xiaomihome.class.php
+++ b/core/class/xiaomihome.class.php
@@ -487,7 +487,7 @@ class xiaomihome extends eqLogic {
                     if ($value>=3100) {
                         $battery = 100;
                     } else if ($value<3100 && $value>2800) {
-                        $battery = ($value - 2800) *0.33;
+                        $battery = ceil(($value - 2800) *0.33);
                     } else {
                         $battery = 1;
                     }


### PR DESCRIPTION
Le calcul du pourcentage de batterie restant n'est pas précis car la batterie ne se décharge pas linéairement.
Il n'est pas donc nécessaire de prendre en compte les chiffres après la virgule.