### PR TITLE
Ortographe

### DIFF
--- a/doc/fr_FR/yeelight.asciidoc
+++ b/doc/fr_FR/yeelight.asciidoc
@@ -40,11 +40,11 @@ C'est une commande message qui doit avoir par exemple :
 
 - le troisième élément est la suite des états avec leur transition, il y en a 4 possible (attention à bien ne pas mettre d'espaces)
 
-  - hsv : pramètres (hue,saturation,duration=300,brightness=100)
+  - hsv : paramètres (hue,saturation,duration=300,brightness=100)
 
-  - rgb : pramètres (red,green,blue,duration=300,brightness=100)
+  - rgb : paramètres (red,green,blue,duration=300,brightness=100)
 
-  - temp : pramètres (degrees,duration=300,brightness=100)
+  - temp : paramètres (degrees,duration=300,brightness=100)
 
   - wait(duration=300)
 


### PR DESCRIPTION
Ajout du "a" manquant sur le mot "paramètres" dans la description de la commande enchainement