### PR TITLE
Enhancing: fix address already in use

### DIFF
--- a/resources/xiaomihomed/devices/aquara.py
+++ b/resources/xiaomihomed/devices/aquara.py
@@ -27,7 +27,8 @@ class XiaomiConnector:
 	def _prepare_socket(self):
 		sock = socket.socket(socket.AF_INET,  # Internet
 							 socket.SOCK_DGRAM)  # UDP
-
+		
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 		sock.bind(("0.0.0.0", self.MULTICAST_PORT))
 
 		mreq = struct.pack("=4sl", socket.inet_aton(self.MULTICAST_ADDRESS),


### PR DESCRIPTION
Quand domoticz est utilisé sur le raspberry et que je rédemarre ce dernier. Le port 9898 devient source de problème avec xiamihomed (voir img: https://i.imgur.com/xlnF5vr.png). Par conséquent certains capteurs comme aquara mouvements sont HS. Donc voici comment je le corrige.